### PR TITLE
Add vendor modal and embedded mode support

### DIFF
--- a/BizsolERP/Bizsol.ERP.UI.Purchase.Transactions/Areas/PurchaseTransactions/Views/PurchaseOrder/PurchaseOrderStore.cshtml
+++ b/BizsolERP/Bizsol.ERP.UI.Purchase.Transactions/Areas/PurchaseTransactions/Views/PurchaseOrder/PurchaseOrderStore.cshtml
@@ -450,6 +450,17 @@
         border-color: #667eea; box-shadow: 0 0 0 3px rgba(102,126,234,0.15); outline: none;
     }
     .bts-panel .select2-container--default .select2-selection--single .select2-selection__placeholder { color: #94a3b8; }
+    /* ── VENDOR ADD BUTTON ───────────────────────────── */
+    .vendor-add-btn {
+        display: inline-flex; align-items: center; justify-content: center;
+        width: 30px; height: 30px; border-radius: 8px;
+        background: linear-gradient(135deg, #667eea, #764ba2);
+        border: none; color: #fff; cursor: pointer; flex-shrink: 0;
+        font-size: 0.85rem; box-shadow: 0 2px 8px rgba(102,126,234,0.35);
+        transition: all 0.18s;
+    }
+    .vendor-add-btn:hover { transform: scale(1.12); box-shadow: 0 4px 12px rgba(102,126,234,0.5); }
+
     /* ── PAYMENT TERMS ADD BUTTON ──────────────────── */
     .pt-add-btn {
         display: inline-flex; align-items: center; justify-content: center;
@@ -572,8 +583,13 @@
                         </div>
                         <div class="po-field-row">
                             <span class="po-field-lbl">Vendor Name <span class="req">*</span></span>
-                            <div class="po-field-ctrl">
-                                <select id="frmDdlVendor" class="form-control form-control-sm"></select>
+                            <div class="po-field-ctrl d-flex align-items-center gap-2">
+                                <div style="flex:1;min-width:0;">
+                                    <select id="frmDdlVendor" class="form-control form-control-sm"></select>
+                                </div>
+                                <button type="button" class="vendor-add-btn" onclick="OpenVendorModal()" title="Add New Vendor">
+                                    <i class="fa fa-plus"></i>
+                                </button>
                             </div>
                         </div>
                     </div>
@@ -1185,6 +1201,30 @@
                         style="background:linear-gradient(135deg,#34d399,#059669);border:none;color:#fff;border-radius:8px;padding:7px 22px;font-size:0.82rem;font-weight:700;box-shadow:0 3px 10px rgba(5,150,105,0.3);">
                     <i class="fa fa-save me-1"></i>Save
                 </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- ══════════════════════════════════════════════════════
+     ADD VENDOR MODAL (iframe)
+═══════════════════════════════════════════════════ -->
+<div class="modal fade" id="modalAddVendor" tabindex="-1" aria-labelledby="modalAddVendorLabel" aria-hidden="true"
+     data-bs-backdrop="static" data-bs-keyboard="false">
+    <div class="modal-dialog modal-dialog-centered" style="max-width:96vw;width:96vw;">
+        <div class="modal-content" style="height:90vh;border-radius:16px;overflow:hidden;border:none;display:flex;flex-direction:column;">
+            <div class="modal-header" style="background:linear-gradient(135deg,#667eea,#764ba2);color:#fff;border:none;padding:12px 18px;flex-shrink:0;">
+                <h5 class="modal-title mb-0" id="modalAddVendorLabel" style="font-size:0.92rem;font-weight:700;">
+                    <i class="fa fa-user-tie me-2"></i>Add New Vendor
+                </h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body p-0" style="flex:1;overflow:hidden;">
+                <iframe id="iframeVendorMaster"
+                        src=""
+                        style="width:100%;height:100%;border:none;display:block;"
+                        title="Vendor Master">
+                </iframe>
             </div>
         </div>
     </div>

--- a/BizsolERP/Bizsol.ERP.UI.Purchase.Transactions/wwwroot/Script/PurchaseOrderStore.js
+++ b/BizsolERP/Bizsol.ERP.UI.Purchase.Transactions/wwwroot/Script/PurchaseOrderStore.js
@@ -1939,3 +1939,25 @@ window.ConfirmCancelPO = ConfirmCancelPO;
 window.OpenAddSiteRepModal = OpenAddSiteRepModal;
 window.SaveSiteRepresentative = SaveSiteRepresentative;
 
+// ── Vendor Master Modal ──────────────────────────────────────────────────────
+
+function OpenVendorModal() {
+    const baseUrl = sessionStorage.getItem('AppBaseURL') || '';
+    document.getElementById('iframeVendorMaster').src = baseUrl + '/MarketingMasters/VendorMaster/VendorMaster?embedded=1&ModuleDesp=Vendor%20Master';
+    var modal = new bootstrap.Modal(document.getElementById('modalAddVendor'), {
+        backdrop: 'static',
+        keyboard: false
+    });
+    modal.show();
+}
+
+// When vendor modal closes, reload vendor dropdown to pick up newly added vendor
+document.getElementById('modalAddVendor').addEventListener('hidden.bs.modal', function () {
+    document.getElementById('iframeVendorMaster').src = '';
+    if (typeof LoadVendorDropdown === 'function') {
+        LoadVendorDropdown();
+    }
+});
+
+window.OpenVendorModal = OpenVendorModal;
+

--- a/BizsolERP/BizsolERPMain/Views/Shared/_Layout.cshtml
+++ b/BizsolERP/BizsolERPMain/Views/Shared/_Layout.cshtml
@@ -1112,6 +1112,27 @@
             to   { opacity: 1; }
         }
 
+        /* ── Embedded / iframe mode ─────────────────────────────────────────
+           When the page is loaded with ?embedded=1 (e.g. inside a modal iframe)
+           the header, sidebar, footer and mobile nav are hidden and the content
+           area fills the full viewport with no extra margins.
+        ─────────────────────────────────────────────────────────────────── */
+        body.erp-embedded .modern-header,
+        body.erp-embedded .modern-sidebar,
+        body.erp-embedded footer.modern-footer,
+        body.erp-embedded .mobile-bottom-nav,
+        body.erp-embedded #sidebar-overlay {
+            display: none !important;
+        }
+
+        body.erp-embedded .modern-content {
+            margin-left: 0 !important;
+            margin-top: 0 !important;
+            padding: 1rem !important;
+            padding-bottom: 1rem !important;
+            min-height: 100vh;
+        }
+
         /* ERP Heading */
         .erp-heading-wrapper {
             flex: 1;
@@ -1435,7 +1456,7 @@
             }
     </style>
 </head>
-<body>
+<body class="@(Context.Request.Query["embedded"] == "1" ? "erp-embedded" : "")">
     <!-- Loader (hidden by default) -->
     <div id="loader" class="loader-overlay">
         <img src="~/assets/images/loader2.gif" alt="Loading..." class="loader-img">


### PR DESCRIPTION
Add vendor modal and embedded mode support

Introduced an "Add Vendor" button with modal/iframe to allow adding vendors directly from the Purchase Order form. Added CSS and JS for modal handling and dropdown refresh. Implemented "embedded" mode in layout to hide navigation and expand content when loaded in an iframe.

#### PR Classification
New feature: enhances vendor management workflow and supports embedded modal usage.

#### PR Summary
This pull request adds an "Add Vendor" modal with iframe integration and introduces an embedded mode for modal/iframe contexts.
- PurchaseOrderStore.cshtml: Added "Add Vendor" button, modal dialog, and related styles.
- PurchaseOrderStore.js: Implemented modal open/close logic and vendor dropdown refresh.
- _Layout.cshtml: Added embedded mode styles and conditional body class for iframe/modal support.
